### PR TITLE
誰を選択しても同じトークルームに飛ばされていたバグ修正

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,16 +20,16 @@ class GroupsController < ApplicationController
     end
 
       user_ids = (selected_ids + [ current_user.id ]).uniq.sort
-      
+
       group_id = Group
         .joins(:group_users)
-        .group('groups.id')
+        .group("groups.id")
         .having(
-          'COUNT(DISTINCT group_users.user_id) = ? AND ' \
-          'COUNT(DISTINCT CASE WHEN group_users.user_id IN (?) THEN group_users.user_id END) = ?',
+          "COUNT(DISTINCT group_users.user_id) = ? AND " \
+          "COUNT(DISTINCT CASE WHEN group_users.user_id IN (?) THEN group_users.user_id END) = ?",
           user_ids.size, user_ids, user_ids.size
         )
-        .pluck('groups.id')
+        .pluck("groups.id")
         .first
 
     if group_id.present?

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -11,18 +11,27 @@ class GroupsController < ApplicationController
 
 
   def create
-    selected_ids = []
-    selected_ids += Array(params[:user_ids]).map(&:to_i)
+    selected_ids = Array(params[:user_ids]).map(&:to_i)
     selected_ids << params[:user_id].to_i if params[:user_id].present?
 
     if selected_ids.blank?
       redirect_to new_group_path, alert: "メンバーを選択してください"
       return
     end
-      user_ids = (selected_ids + [ current_user.id ]).uniq
-      group_users = GroupUser.where(user_id: user_ids)
-      grouped =group_users.group_by { |group_user| group_user.group_id }
-      group_id = grouped.find { |group_id, users|users.map(&:user_id).uniq.sort == user_ids.sort }&.first
+
+      user_ids = (selected_ids + [ current_user.id ]).uniq.sort
+      
+      group_id = Group
+        .joins(:group_users)
+        .group('groups.id')
+        .having(
+          'COUNT(DISTINCT group_users.user_id) = ? AND ' \
+          'COUNT(DISTINCT CASE WHEN group_users.user_id IN (?) THEN group_users.user_id END) = ?',
+          user_ids.size, user_ids, user_ids.size
+        )
+        .pluck('groups.id')
+        .first
+
     if group_id.present?
       @group = Group.find(group_id)
       redirect_to group_path(@group), notice: "グループに入室しました"

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,2 @@
+class Relationship < ApplicationRecord
+end

--- a/db/migrate/20250810084628_create_relationships.rb
+++ b/db/migrate/20250810084628_create_relationships.rb
@@ -2,11 +2,11 @@ class CreateRelationships < ActiveRecord::Migration[8.0]
   def change
     create_table :relationships do |t|
       t.references :user
-      t.references :follower, foreign_key: {to_table: :users}
+      t.references :follower, foreign_key: { to_table: :users }
 
       t.timestamps
 
-      t.index [:user_id, :follower_id], unique: true
+      t.index [ :user_id, :follower_id ], unique: true
     end
   end
 end

--- a/db/migrate/20250810084628_create_relationships.rb
+++ b/db/migrate/20250810084628_create_relationships.rb
@@ -1,0 +1,12 @@
+class CreateRelationships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :relationships do |t|
+      t.references :user
+      t.references :follower, foreign_key: {to_table: :users}
+
+      t.timestamps
+
+      t.index [:user_id, :follower_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_02_103841) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_10_084628) do
   create_table "group_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "group_id", null: false
@@ -36,6 +36,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_02_103841) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
+  create_table "relationships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "follower_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
+    t.index ["user_id", "follower_id"], name: "index_relationships_on_user_id_and_follower_id", unique: true
+    t.index ["user_id"], name: "index_relationships_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -53,4 +63,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_02_103841) do
   add_foreign_key "group_users", "users"
   add_foreign_key "posts", "groups"
   add_foreign_key "posts", "users"
+  add_foreign_key "relationships", "users", column: "follower_id"
 end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
グループを作成しても、個人チャットにしても既存のグループ1に飛ばされていたので、グループ判別を行う条件式を見直した。