### PR TITLE
グループコントローラーの可読性を上げるためにクラスメソッド化とコールバックを導入した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,12 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
   end
+
+  def after_sign_in_path_for(resource)
+    users_path
+  end
+
+  def after_sign_out_path_for(resource)
+    new_user_session_path
+  end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -11,38 +11,22 @@ class GroupsController < ApplicationController
 
 
   def create
-    selected_ids = Array(params[:user_ids]).map(&:to_i)
-    selected_ids << params[:user_id].to_i if params[:user_id].present?
+    selected_ids = (Array(params[:user_ids]) + [ params[:user_id] ]).map(&:to_i)
 
-    if selected_ids.blank?
-      redirect_to new_group_path, alert: "メンバーを選択してください"
-      return
-    end
-
-      user_ids = (selected_ids + [ current_user.id ]).uniq.sort
-
-      group_id = Group
-        .joins(:group_users)
-        .group("groups.id")
-        .having(
-          "COUNT(DISTINCT group_users.user_id) = ? AND " \
-          "COUNT(DISTINCT CASE WHEN group_users.user_id IN (?) THEN group_users.user_id END) = ?",
-          user_ids.size, user_ids, user_ids.size
-        )
-        .pluck("groups.id")
-        .first
+    user_ids = Group.build_user_ids(selected_ids, current_user.id)
+    group_id = Group.id_for_exact_members(user_ids)
 
     if group_id.present?
-      @group = Group.find(group_id)
-      redirect_to group_path(@group), notice: "グループに入室しました"
+      redirect_to group_path(group_id), notice: "グループに入室しました"
     else
-      names = User.where(id: user_ids).pluck(:name)
-      group_name = names.size <= 2 ? names.join("、") : "#{names.first(2).join("、")}..."
-      @group= Group.create(name: group_name)
+      group = Group.create(name: "")
+      user_ids = (selected_ids + [ current_user.id ]).uniq
       user_ids.each do |user_id|
-        GroupUser.create(user_id: user_id, group_id: @group.id)
-      end
-        redirect_to group_path(@group), notice: "グループを作成しました"
+      GroupUser.create(user_id: user_id, group_id: group.id)
+    end
+      group.update_default_name
+
+      redirect_to group_path(group), notice: "グループを作成しました"
     end
   end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,0 +1,2 @@
+class Friendship < ApplicationRecord
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,45 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
 
   has_many :posts
+
+
+  def Group.build_user_ids(selected_ids, current_user_id)
+    (Array(selected_ids).map(&:to_i) + [ current_user_id ]).uniq.sort
+  end
+
+
+  def Group.id_for_exact_members(user_ids)
+    ids = Array(user_ids).map(&:to_i).uniq.sort
+    return nil if ids.blank?
+
+    joins(:group_users)
+      .group("groups.id")
+      .having(
+        "COUNT(DISTINCT group_users.user_id) = ? AND " \
+        "COUNT(DISTINCT CASE WHEN group_users.user_id IN (?) " \
+        "THEN group_users.user_id END) = ?",
+        ids.size, ids, ids.size
+      )
+      .pick("groups.id")
+  end
+
+  def update_default_name(user_ids: nil)
+    return if name.present?
+
+    names =
+      if user_ids
+        User.where(id: user_ids).pluck(:name)
+      else
+        users.reload.pluck(:name)
+      end
+
+    new_name =
+      if names.size <= 2
+        names.join("、")
+      else
+        "#{names.first(2).join("、")}..."
+      end
+
+    update!(name: new_name)
+  end
 end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,4 +1,12 @@
 class GroupUser < ApplicationRecord
   belongs_to :user
   belongs_to :group
+
+  after_create :set_group_name
+
+  private
+
+  def set_group_name
+    group.update_default_name
+  end
 end

--- a/db/migrate/20250813083721_create_friendships.rb
+++ b/db/migrate/20250813083721_create_friendships.rb
@@ -1,0 +1,10 @@
+class CreateFriendships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :friendships do |t|
+      t.references :requester, null: false, foreign_key: { to_table: :users }
+      t.references :addressee, null: false, foreign_key: { to_table: :users }
+      t.integer :status, null: false, default: 0
+      t.index [ :requester_id, :addressee_id ], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_10_084628) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_13_083721) do
+  create_table "friendships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "requester_id", null: false
+    t.bigint "addressee_id", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["addressee_id"], name: "index_friendships_on_addressee_id"
+    t.index ["requester_id", "addressee_id"], name: "index_friendships_on_requester_id_and_addressee_id", unique: true
+    t.index ["requester_id"], name: "index_friendships_on_requester_id"
+  end
+
   create_table "group_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "group_id", null: false
@@ -59,6 +70,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_10_084628) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "friendships", "users", column: "addressee_id"
+  add_foreign_key "friendships", "users", column: "requester_id"
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
   add_foreign_key "posts", "groups"

--- a/test/fixtures/friendships.yml
+++ b/test/fixtures/friendships.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/friendship_test.rb
+++ b/test/models/friendship_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FriendshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
グループコントローラーの可読性を上げるためにクラスメソッド化を行い、とグループを作った際に、名前を作るコールバックを導入した。